### PR TITLE
Fix #88 article stars

### DIFF
--- a/Components/Shared.cs
+++ b/Components/Shared.cs
@@ -11,6 +11,7 @@
 \*---------------------------------------------------------*/
 
 using System;
+using Microsoft.AspNetCore.Http;
 
 namespace ZeroWeb
 {
@@ -77,6 +78,15 @@ namespace ZeroWeb
                 // Display the full date.
                 return date.ToString("M/d/yy h:mm tt").ToLower();
             }
+        }
+
+        /// <summary>
+        /// Gets the request IP address.
+        /// </summary>
+        /// <returns>The request IP address.</returns>
+        public static string GetRequestIpAddress(HttpRequest request)
+        {
+            return request.HttpContext.Connection.RemoteIpAddress.ToString();
         }
     }
 }

--- a/Components/SiteDataStore.cs
+++ b/Components/SiteDataStore.cs
@@ -224,9 +224,17 @@ namespace ZeroWeb
         {
             var result = this.context.SiteItems.Where(item => item.Id == id).FirstOrDefault();
 
-            if (result != null && result.Comments == null)
+            if (result != null)
             {
-                result.Comments = new List<Comment>();
+                if (result.Comments == null)
+                {
+                    result.Comments = new List<Comment>();
+                }
+
+                if (result.Stars == null)
+                {
+                    result.Stars = new List<Star>();
+                }
             }
 
             return result;
@@ -243,6 +251,16 @@ namespace ZeroWeb
                                          .Select(result => result.Comments.ToArray());
         }
 
+        /// <summary>
+        /// Gets the site item stars.
+        /// </summary>
+        /// <param name="id">The site item Id.</param>
+        /// <returns>The stars for the site item.</returns>
+        public IQueryable<Star> GetItemStars(int id)
+        {
+            return this.context.Stars.Where(star => star.Item.Id == id);
+        }
+        
         /// <summary>
         /// Adds a new tag.
         /// </summary>

--- a/Controllers/newsController.cs
+++ b/Controllers/newsController.cs
@@ -50,6 +50,7 @@ namespace ZeroWeb.Controllers
                     title = item.Title,
                     date = item.Date,
                     author = item.Author.Name,
+                    stars = item.Stars,
                     location = item.LocationName,
                     latitude = item.LocationLatitude,
                     longitude = item.LocationLongitude,
@@ -66,6 +67,7 @@ namespace ZeroWeb.Controllers
                     story.title = result.title;
                     story.date = result.date;
                     story.author = result.author;
+                    story.stars = result.stars;
                     story.location = result.location;
                     story.latitude = result.latitude;
                     story.longitude = result.longitude;

--- a/Controllers/newsController.cs
+++ b/Controllers/newsController.cs
@@ -41,6 +41,7 @@ namespace ZeroWeb.Controllers
         public IActionResult Index()
         {
             string excludeTag = Tags.Story.ToString().ToLower();
+            string excludeIpAddress = Shared.GetRequestIpAddress(this.Request);
 
             return View(this.store
                 .GetItems(Tags.Story)
@@ -50,7 +51,8 @@ namespace ZeroWeb.Controllers
                     title = item.Title,
                     date = item.Date,
                     author = item.Author.Name,
-                    stars = item.Stars,
+                    stars = item.Stars.Count,
+                    starsReadOnly = item.Stars.Any(star => star.IpAddress == excludeIpAddress),
                     location = item.LocationName,
                     latitude = item.LocationLatitude,
                     longitude = item.LocationLongitude,
@@ -68,6 +70,7 @@ namespace ZeroWeb.Controllers
                     story.date = result.date;
                     story.author = result.author;
                     story.stars = result.stars;
+                    story.starsReadOnly = result.starsReadOnly;
                     story.location = result.location;
                     story.latitude = result.latitude;
                     story.longitude = result.longitude;

--- a/Interfaces/IDataStore.cs
+++ b/Interfaces/IDataStore.cs
@@ -98,6 +98,13 @@ namespace ZeroWeb
         IQueryable<Comment[]> GetItemComments(int id);
 
         /// <summary>
+        /// Gets the site item stars.
+        /// </summary>
+        /// <param name="id">The site item Id.</param>
+        /// <returns>The stars for the site item.</returns>
+        IQueryable<Star> GetItemStars(int id);
+
+        /// <summary>
         /// Adds a new site item.
         /// </summary>
         /// <param name="item">The site item to add.</param>

--- a/Migrations/20161018152526_Stars.Designer.cs
+++ b/Migrations/20161018152526_Stars.Designer.cs
@@ -8,9 +8,10 @@ using ZeroWeb.Models;
 namespace zeroweb.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20161018152526_Stars")]
+    partial class Stars
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.0.0-rtm-21431");

--- a/Migrations/20161018152526_Stars.cs
+++ b/Migrations/20161018152526_Stars.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace zeroweb.Migrations
+{
+    public partial class Stars : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Stars",
+                table: "SiteItems",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Stars",
+                table: "SiteItems");
+        }
+    }
+}

--- a/Migrations/20161019195522_StarsTable.Designer.cs
+++ b/Migrations/20161019195522_StarsTable.Designer.cs
@@ -8,9 +8,10 @@ using ZeroWeb.Models;
 namespace zeroweb.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20161019195522_StarsTable")]
+    partial class StarsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.0.0-rtm-21431");

--- a/Migrations/20161019195522_StarsTable.cs
+++ b/Migrations/20161019195522_StarsTable.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace zeroweb.Migrations
+{
+    public partial class StarsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Stars",
+                table: "SiteItems");
+
+            migrationBuilder.CreateTable(
+                name: "Stars",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Autoincrement", true),
+                    IpAddress = table.Column<string>(type: "char", maxLength: 16, nullable: false),
+                    ItemId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Stars", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Stars_SiteItems_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "SiteItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Stars_ItemId",
+                table: "Stars",
+                column: "ItemId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Stars");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Stars",
+                table: "SiteItems",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/Models/Context.cs
+++ b/Models/Context.cs
@@ -41,6 +41,11 @@ namespace ZeroWeb.Models
         public DbSet<SiteItem> SiteItems { get; set; }
 
         /// <summary>
+        /// Gets or sets the site item stars.
+        /// </summary>
+        public DbSet<Star> Stars { get; set; }
+
+        /// <summary>
         /// Gets or sets the tag taxonomy.
         /// </summary>
         public DbSet<Tag> Tags { get; set; }

--- a/Models/SiteItem.cs
+++ b/Models/SiteItem.cs
@@ -40,6 +40,11 @@ namespace ZeroWeb.Models
         public bool Published { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of times the article was starred as favorite.
+        /// </summary>
+        public int Stars { get; set; }
+
+        /// <summary>
         /// Gets or sets the publish geographical location name where the item was authored.
         /// </summary>
         [MaxLength(32)]

--- a/Models/SiteItem.cs
+++ b/Models/SiteItem.cs
@@ -40,11 +40,6 @@ namespace ZeroWeb.Models
         public bool Published { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of times the article was starred as favorite.
-        /// </summary>
-        public int Stars { get; set; }
-
-        /// <summary>
         /// Gets or sets the publish geographical location name where the item was authored.
         /// </summary>
         [MaxLength(32)]
@@ -74,6 +69,11 @@ namespace ZeroWeb.Models
         /// Gets or sets the item comments.
         /// </summary>
         public ICollection<Comment> Comments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item stars.
+        /// </summary>
+        public ICollection<Star> Stars { get; set; }
 
         /// <summary>
         /// Gets or sets the project tasks if this article is a project.

--- a/Models/Stars.cs
+++ b/Models/Stars.cs
@@ -1,0 +1,63 @@
+/*--------------------------------------------------------*\
+|   ______    __   |
+|  |  __  |  |  |  |
+|  | |  | |  |  |  |
+|  | !__! |  |  |  |
+|  !______!  !__!  |  binary : tech art
+|
+|  Defines site item stars.
+|----------------------------------------------------------
+|  Copyright(C) 2016 Valeriy Novytskyy
+\*---------------------------------------------------------*/
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ZeroWeb.Models
+{
+    /// <summary>
+    /// Star a site item.
+    /// </summary>
+    [Table("Stars")]
+    public class Star
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Star"/> class.
+        /// </summary>
+        public Star()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Star"/> class.
+        /// </summary>
+        /// <param name="item">The item the star is for.</param>
+        /// <param name="ip">The external identity starring the site item.</param>
+        public Star(SiteItem item, string ip)
+        {
+            this.Item = item;
+            this.IpAddress = ip;
+        }
+
+        /// <summary>
+        /// Gets or sets the primary key.
+        /// </summary>
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the site item this star is for.
+        /// </summary>
+        [Required]
+        public SiteItem Item { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comment author identity.
+        /// </summary>
+        [Required]
+        [MaxLength(16)]
+        [Column(TypeName="char")]
+        public string IpAddress { get; set; }
+    }
+}

--- a/Services/NewsService.cs
+++ b/Services/NewsService.cs
@@ -82,5 +82,34 @@ namespace ZeroWeb.API
 
             return Ok(new { store.GetItem(id).Content });
         }
+
+        /// <summary>
+        /// Star a news story.
+        /// </summary>
+        /// <param name="id">The story id</param>
+        [HttpPost("star")]
+        public IActionResult Star(int id)
+        {
+            IDataStore store = this.services.GetService(typeof(IDataStore)) as IDataStore;
+            var item = store.GetItem(id);
+
+            if (item == null)
+            {
+                return NotFound();
+            }
+
+            item.Stars++;
+
+            try
+            {
+                store.Save();
+            }
+            catch (Exception ex)
+            {
+                return this.StatusCode(500, ex.Message);
+            }
+
+            return Ok(new { store.GetItem(id).Content });
+        }
     }
 }

--- a/Styles/_media.desktop.scss
+++ b/Styles/_media.desktop.scss
@@ -881,10 +881,27 @@ a.author:hover
     stroke: $primary-hover-color;
 }
 
+.metadata-icon-readonly
+{
+    cursor: default;
+}
+
 .metadata-icon-toggled
 {
     fill: $primary-color;
     stroke: $primary-color;
+}
+
+.metadata-icon-readonly.metadata-icon-toggled
+{
+    fill: $primary-light-color;
+    stroke: $primary-light-color;
+}
+
+.metadata-icon-readonly.metadata-icon-toggled:hover
+{
+    fill: $primary-light-color;
+    stroke: $primary-light-color;
 }
 
 .article

--- a/Styles/_media.desktop.scss
+++ b/Styles/_media.desktop.scss
@@ -857,6 +857,36 @@ a.author:hover
     letter-spacing: $small-font-letter-spacing-win;
 }
 
+.metadata-action
+{
+    margin-left: $border-thickness * 3;
+    margin-right: $border-thickness * 3;
+}
+
+.metadata-icon
+{
+    position: relative;
+    display: inline-block;
+    fill: $accent-color;
+    stroke: $accent-color;
+    width: 16px;
+    height: 16px;
+    top: 3px;
+    cursor: pointer;
+}
+
+.metadata-icon:hover
+{
+    fill: $primary-hover-color;
+    stroke: $primary-hover-color;
+}
+
+.metadata-icon-toggled
+{
+    fill: $primary-color;
+    stroke: $primary-color;
+}
+
 .article
 {
     border-bottom: $border-thickness dotted $shadow-light-color;

--- a/Views/News/Index.cshtml
+++ b/Views/News/Index.cshtml
@@ -9,6 +9,8 @@
 @foreach (var story in this.Model)
 {
     var storyId = story.id;
+    var starClass = "metadata-icon" +
+        (story.stars > 0 ? " metadata-icon-toggled" : string.Empty);
 
 <div class="article">
     <!-- Story title -->
@@ -40,6 +42,17 @@
                 @story.location
             }
         }
+
+        <!-- Stars -->
+        <span id="star-@storyId" class="metadata-action">
+            <icon class="@starClass"
+                data-src="images/banner.svg#star"
+                data-width="16"
+                data-height="16"
+                data-ng-click="news.addStar(@storyId)">
+            </icon>
+            @story.stars
+        </span>
 
         <!-- Tags -->
         <span class="tags">

--- a/Views/News/Index.cshtml
+++ b/Views/News/Index.cshtml
@@ -10,7 +10,8 @@
 {
     var storyId = story.id;
     var starClass = "metadata-icon" +
-        (story.stars > 0 ? " metadata-icon-toggled" : string.Empty);
+        (story.stars > 0 ? " metadata-icon-toggled" : string.Empty) +
+        (story.starsReadOnly ? " metadata-icon-readonly" : string.Empty);
 
 <div class="article">
     <!-- Story title -->
@@ -51,7 +52,9 @@
                 data-height="16"
                 data-ng-click="news.addStar(@storyId)">
             </icon>
-            @story.stars
+            <span class="metadata-content">
+                @story.stars
+            </span>
         </span>
 
         <!-- Tags -->

--- a/scripts/app/controllers/newsController.js
+++ b/scripts/app/controllers/newsController.js
@@ -301,16 +301,23 @@
          */
         function addStar(storyId)
         {
-            this.commentsStore.star(
+            var $star = $("#star-" + storyId);
+
+            if ($star.find("metadata-icon-readonly").length > 0)
+                return;
+
+            this.newsStore.star(
                 {
                     id: storyId
                 },
 
                 function(result)
                 {
-                    var $star = $("#star-" + storyId);
-                    var count = parseInt($star.text()) + 1;
-                    $star.text(count);
+                    $star.find(".metadata-icon")
+                        .addClass("metadata-icon-readonly")
+                        .addClass("metadata-icon-toggled");
+
+                    $star.find(".metadata-content").text(result.stars);
 
                 }.bind(this),
 

--- a/scripts/app/controllers/newsController.js
+++ b/scripts/app/controllers/newsController.js
@@ -135,6 +135,12 @@
         this.addComment = addComment;
 
         /**
+         * Add a story star (favorite).
+         * @type {function}
+         */
+        this.addStar = addStar;
+
+        /**
          * Authenticate user.
          * @type {function}
          */
@@ -287,6 +293,34 @@
 
             this.commentError[storyId] = null;
             this.newComment[storyId] = null;
+        }
+
+        /**
+         * Add a story star.
+         * @param {int} storyId - The id of the story to star.
+         */
+        function addStar(storyId)
+        {
+            this.commentsStore.star(
+                {
+                    id: storyId
+                },
+
+                function(result)
+                {
+                    var $star = $("#star-" + storyId);
+                    var count = parseInt($star.text()) + 1;
+                    $star.text(count);
+
+                }.bind(this),
+
+                function(error)
+                {
+                    this.commentOperation[storyId] = "add a star";
+                    this.commentError[storyId] = error;
+
+                }.bind(this)
+            );
         }
     }
 

--- a/scripts/app/factories/commentsFactory.js
+++ b/scripts/app/factories/commentsFactory.js
@@ -29,8 +29,7 @@
      */
     function commentsFactory($resource)
     {
-        return $resource
-        (
+        return $resource(
             "/services/comments/:id",
 
             {},

--- a/scripts/app/factories/newsFactory.js
+++ b/scripts/app/factories/newsFactory.js
@@ -33,13 +33,14 @@
             "/services/news/:id",
 
             {
+                id: '@id'
             },
             
             {
                 "star":
                 {
                     method: "POST",
-                    url: "/services/news"
+                    url: "/services/news/star/:id"
                 }
             });
     }

--- a/scripts/app/factories/newsFactory.js
+++ b/scripts/app/factories/newsFactory.js
@@ -29,7 +29,19 @@
      */
     function newsFactory($resource)
     {
-        return $resource("/services/news/:id");
+        return $resource(
+            "/services/news/:id",
+
+            {
+            },
+            
+            {
+                "star":
+                {
+                    method: "POST",
+                    url: "/services/news"
+                }
+            });
     }
 
 })();

--- a/wwwroot/images/banner.svg
+++ b/wwwroot/images/banner.svg
@@ -85,4 +85,8 @@
         <rect x="1" y="8" width="6" height="1"/>
         <path d="M6,7,3,4V2.87l2.6,2.6V.27h.8v5.2L9,2.87V4Z"/>
     </symbol>
+
+    <symbol id="star">
+        <polygon points="7.9,0 9.8,5.9 16,5.9 11,9.5 12.9,15.3 7.9,11.7 3,15.3 4.9,9.5 -0.1,5.9 6,5.9 " stroke="none"/>
+    </symbol>
 </svg>


### PR DESCRIPTION
Adding stars indicator to each site item to show how many times it was starred by users. Restricted by IP address instead of user account because making people login to star is too annoying, and if something is truly popular the sock-puppet stars will be lost in real stars (a few extra won't matter). Once starred, the indicator changes style and early-exists on requests to star to indicate it became read only.